### PR TITLE
Megatron now uses the report config

### DIFF
--- a/nightlies.conf
+++ b/nightlies.conf
@@ -38,6 +38,7 @@ apt=
   libpapi-dev
   libpfm4-dev
   ocaml-dune
+report=output/
 
 [MarisaKirisame/ant]
 slack=browsers


### PR DESCRIPTION
You can now get nightly reports uploaded with `report=<dir>` in the nightly config, no need to call `nightly-results`.

By the way, you can also configure a Slack image with `image=<path_in_report_dir>`