### PR TITLE
Auto-upload eggcc

### DIFF
--- a/nightlies.conf
+++ b/nightlies.conf
@@ -18,6 +18,7 @@ report=reports/
 slack=eggcc
 timeout=3hr
 apt=hyperfine jq clang-18 llvm-18 libllvm18 llvm-18-dev llvm-18-runtime libpolly-18-dev libzstd-dev coinor-libcbc-dev
+report=nightly/output/
 
 [egraphs-good/peggy-comparison]
 slack=eggcc


### PR DESCRIPTION
This PR moves `oflatt/eggcc` to the new `report` config option. Note that this is safe even if the eggcc PR isn't merged. @oflatt 